### PR TITLE
added amqp_login_plain method

### DIFF
--- a/include/amqp.h
+++ b/include/amqp.h
@@ -1793,6 +1793,13 @@ AMQP_CALL amqp_login(amqp_connection_state_t state, char const *vhost,
                      int channel_max, int frame_max, int heartbeat,
                      amqp_sasl_method_enum sasl_method, ...);
 
+extern inline amqp_rpc_reply_t amqp_login_plain(
+  amqp_connection_state_t state, char const *vhost, int channel_max,
+  int frame_max, int heartbeat, const char * username, const char * password) {
+    return amqp_login(state, vhost, channel_max, frame_max, heartbeat,
+      AMQP_SASL_METHOD_PLAIN, username, password);
+}
+
 /**
  * Login to the broker passing a properties table
  *


### PR DESCRIPTION
`amqp_login` can't be called on linux swift3 as it doesn't support variadic c function calls. I added a method `amqp_login_plain` that simply calls `amqp_login` and passed AMQP_SASL_METHOD_PLAIN for the SASL method and provides two non-variadic arguments for username and password.
